### PR TITLE
Readme hack

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# <img src='https://rawgithub.com/FortAwesome/Font-Awesome/master/advanced-options/raw-svg/brands/wikipedia-w.svg' card_color='#000000' width='50' height='50' style='vertical-align:bottom'/> Wikipedia
+# <img src='https://rawgithub.com/FortAwesome/./Font-Awesome/master/advanced-options/raw-svg/brands/wikipedia-w.svg' card_color='#000000' width='50' height='50' style='vertical-align:bottom'/> Wikipedia
 Wikipedia
 
 ## About 


### PR DESCRIPTION
Attempting to hack the way the Wikipedia logo gets pulled in, since the "brands" isn't easily accessed in the Marketplace.  I added a "/./" to the path, so the harvest script will not match the expected path to fontawesome logos and treat it as a regular img.