### PR TITLE
Bugfix - tests failing on slow responses

### DIFF
--- a/test/behave/steps/wiki.py
+++ b/test/behave/steps/wiki.py
@@ -1,7 +1,11 @@
+import time 
+
 from behave import then
 
 from mycroft.audio import wait_while_speaking
 
 @then('wait while speaking')
 def handle_wait(context):
+    # add sleep to ensure there is a delay when using a dummy TTS eg CI
+    time.sleep(3)
     wait_while_speaking()

--- a/test/behave/steps/wiki.py
+++ b/test/behave/steps/wiki.py
@@ -1,0 +1,7 @@
+from behave import then
+
+from mycroft.audio import wait_while_speaking
+
+@then('wait while speaking')
+def handle_wait(context):
+    wait_while_speaking()

--- a/test/behave/wiki.feature
+++ b/test/behave/wiki.feature
@@ -4,6 +4,7 @@ Feature: Wikipedia Skill
     Given an english speaking user
      When the user says "<tell me about a person>"
      Then "skill-wiki" should reply with dialog from "searching.dialog"
+     And wait while speaking
      And mycroft reply should contain "<person>"
 
   Examples: user asks a question about a person
@@ -30,6 +31,7 @@ Feature: Wikipedia Skill
     Given an english speaking user
      When the user says "<tell me about a place>"
      Then "mycroft-wiki" should reply with dialog from "searching.dialog"
+     And wait while speaking
      And mycroft reply should contain "<place>"
 
   Examples: user asks a question about a place
@@ -43,6 +45,7 @@ Feature: Wikipedia Skill
     Given an english speaking user
      When the user says "<tell me about a thing>"
      Then "mycroft-wiki" should reply with dialog from "searching.dialog"
+     And wait while speaking
      And mycroft reply should contain "<thing>"
 
   Examples: user asks a question about a place
@@ -66,6 +69,7 @@ Feature: Wikipedia Skill
     Given an english speaking user
      When the user says "<tell me about an idea>"
      Then "mycroft-wiki" should reply with dialog from "searching.dialog"
+     And wait while speaking
      And mycroft reply should contain "<idea>"
 
   Examples: user asks a question about a place

--- a/test/behave/wiki.feature
+++ b/test/behave/wiki.feature
@@ -39,7 +39,6 @@ Feature: Wikipedia Skill
     | tell me about amsterdam | netherlands |
     | tell me about tokyo | japan |
     | tell me about antarctica | pole |
-    | tell me about sandwiches | sandwich |
 
   Scenario Outline: user asks a question about something
     Given an english speaking user
@@ -48,7 +47,7 @@ Feature: Wikipedia Skill
      And wait while speaking
      And mycroft reply should contain "<thing>"
 
-  Examples: user asks a question about a place
+  Examples: user asks a question about a thing
     | tell me about a thing | thing |
     | tell me about sandwiches | sandwich |
     | tell me about hammers | hammer |
@@ -72,7 +71,7 @@ Feature: Wikipedia Skill
      And wait while speaking
      And mycroft reply should contain "<idea>"
 
-  Examples: user asks a question about a place
+  Examples: user asks a question about an idea
     | tell me about an idea | idea |
     | tell me about philosophy | philosophy |
     | tell me about politics | politics |


### PR DESCRIPTION
A number of tests are currently failing for the Wiki Skill, caused by the delay in responding exceeding the default 10 second Voight Kampff Step timeout.

This adds a custom `wait while speaking` step to delay the start of the final `mycroft reply should contain` step for each test. An additional 3 second sleep was added to this to ensure some delay occured given the Docker runs use a dummy TTS and hence wouldn't pause.

This is intended to get the VK tests passing in the short term. More thought needs to go into the best way to handle this going forward to make the test suite more robust.

We also need to investigate ways to speed up the response time from the wikipedia service. A user shouldn't need to wait > 10 seconds for an answer. Options are to switch libraries or reduce the search calls. Currently for a single search we can make up to 3 requests to wikipedia as we:
1. List possible pages
2. Fetch two line summary of most likely page.
3. If too long, re-fetch one line summary

