### PR TITLE
Refactor: splitout Lookup, fix failing "science" testcase

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -194,7 +194,7 @@ class WikipediaSkill(MycroftSkill):
             self.set_context("spoken_lines", str(lines_spoken_already+5))
 
     @intent_handler("Random.intent")
-    def handle_random_intent(self, message):
+    def handle_random_intent(self, _):
         """ Get a random wiki page.
 
         Uses the Special:Random page of wikipedia
@@ -254,7 +254,7 @@ class WikipediaSkill(MycroftSkill):
             lang_dict = self.translate_namedvalues("wikipedia_lang")
             wiki.set_lang(lang_dict["code"])
 
-            # First step is to get wiki article titles.  This comes back
+            # Fet wiki article titles. This comes back
             # as a list.  I.e. "beans" returns ['beans',
             #     'Beans, Beans the Music Fruit', 'Phaseolus vulgaris',
             #     'Baked beans', 'Navy beans']
@@ -265,7 +265,7 @@ class WikipediaSkill(MycroftSkill):
             return PageMatch(results[0], auto_suggest)
 
         except wiki.exceptions.DisambiguationError as e:
-            # Test:  "tell me about john"
+            # Test: "tell me about john"
             return PageDisambiguation(e.options)
 
 

--- a/__init__.py
+++ b/__init__.py
@@ -125,11 +125,7 @@ class WikipediaSkill(MycroftSkill):
     def respond_match(self, match):
         """Respond to user."""
 
-        self.gui.clear()
-        self.gui['summary'] = match.summary
-        self.gui['imgLink'] = match.image
-        self.gui.show_page("WikipediaDelegate.qml", override_idle=60)
-
+        self.display_article(match)
         # Remember context and speak results
         self.set_context("wiki_article", match.serialize())
         self.set_context("spoken_lines", str(match.lines))
@@ -170,12 +166,9 @@ class WikipediaSkill(MycroftSkill):
         if not summary:
             self.speak_dialog("thats all")
         else:
-            self.gui.clear()
-
-            self.gui['summary'] = summary
-            self.gui['imgLink'] = article.image
-            self.gui.show_page("WikipediaDelegate.qml", override_idle=60)
+            self.display_article(article)
             self.speak(summary)
+            # Update context
             self.set_context("wiki_article", article.serialize())
             self.set_context("spoken_lines", str(lines_spoken_already+5))
 
@@ -239,6 +232,12 @@ class WikipediaSkill(MycroftSkill):
             # Test:  "tell me about john"
             return PageDisambiguation(e.options)
 
+
+    def display_article(self, match):
+        self.gui.clear()
+        self.gui['summary'] = match.summary
+        self.gui['imgLink'] = match.image
+        self.gui.show_page("WikipediaDelegate.qml", override_idle=60)
 
 
 def create_skill():

--- a/__init__.py
+++ b/__init__.py
@@ -18,6 +18,7 @@ import re
 import wikipedia as wiki
 from adapt.intent import IntentBuilder
 from mycroft import MycroftSkill, intent_handler
+from mycroft.util.format import join_list
 
 
 EXCLUDED_IMAGES = [
@@ -185,9 +186,7 @@ class WikipediaSkill(MycroftSkill):
     def respond_disambiguation(self, disambiguation):
         """Ask for which of the different matches should be used."""
 
-        options = (", ".join(disambiguation.options[:-1]) + " " +
-                   self.translate("or") + " " + disambiguation.options[-1])
-
+        options = join_list(disambiguation.options, 'or', lang=self.lang)
         choice = self.get_response('disambiguate', data={"options": options})
 
         self.log.info('Disambiguation choice is {}'.format(choice))


### PR DESCRIPTION
#### Description
This started as a fix for the failing lookup of "science" but mutated into some sort of refactoring since the fix required some additional changes and it sort of snowballed. It does however fix the failing test case.

Things done:
*Split the response handling from the lookup code:*
This allows doing the lookup both with auto-suggest and without it. If a Disambiguation result and a Page Match result are both received the page match is used. To keep / improve the speed  auto-suggest and non-autosuggest versions are run in parallell.
 
*Made the skill more stateless*
The article information is no longer passed via the self.result member, instead it's passed through adapt context. This should be better in the cases where multiple clients are connected.

*Minor refactoring*
The repeated gui code was moved into a reusable method. Comments and docstrings were improved. the _lookup method was in the end moved out of the Skill class since it barely uses the class methods.

*Things to note*
The PageDisambiguation class is a bit thin, was mainly created to easily be able to use the response type of the lookup to see what type of response was received. I think it's existence is motivated since it improves readability.

#### Type of PR

- [ x ] Bugfix
- [ ] Feature implementation
- [ x ] Refactor of code (without functional changes)
- [ ] Documentation improvements
- [ ] Test improvements

#### Testing
How can someone reviewing this PR test that it is working properly? Is there appropriate test coverage for this change?

#### Documentation
Does documentation for this already exist? Are there docstrings on all the public methods you added or modified? Have these been updated?

#### CLA
To protect you, the project, and those who choose to use Mycroft technologies in systems they build, we ask all contributors to sign a Contributor License Agreement.

This agreement clarifies that you are granting a license to the Mycroft Project to freely use your work.  Additionally, it establishes that you retain the ownership of your contributed code and intellectual property.  As the owner, you are free to use your code in other work, obtain patents, or do anything else you choose with it.

If you haven't already signed the agreement and been added to our public [Contributors repo](https://github.com/mycroftAI/contributors) then please head to https://mycroft.ai/cla to initiate the signing process.
