### PR TITLE
Fix issue with exploding context trie

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -211,9 +211,10 @@ class WikipediaSkill(MycroftSkill):
         article = self._match
         lines_spoken_already = int(message.data.get("spoken_lines"))
 
-        summary_read = wiki.summary(article.wiki_result, lines_spoken_already)
+        summary_read = wiki.summary(article.wiki_result, lines_spoken_already,
+                                    auto_suggest=article.auto_suggest)
         summary = wiki.summary(article.wiki_result, lines_spoken_already + 5,
-                               article.auto_suggest)
+                               auto_suggest=article.auto_suggest)
 
         # Remove already-spoken parts and section titles
         summary = summary[len(summary_read):]

--- a/__init__.py
+++ b/__init__.py
@@ -146,6 +146,7 @@ class WikipediaSkill(MycroftSkill):
     def __init__(self):
         super(WikipediaSkill, self).__init__(name="WikipediaSkill")
         self._match = None
+        self._lines_spoken_already = 0
 
     @intent_handler(IntentBuilder("").require("Wikipedia").
                     require("ArticleTitle"))
@@ -182,7 +183,7 @@ class WikipediaSkill(MycroftSkill):
         # Remember context and speak results
         self._match = match
         self.set_context("wiki_article", "")
-        self.set_context("spoken_lines", str(match.lines))
+        self._lines_spoken_already = match.lines
         self.speak(match.summary)
 
     def respond_disambiguation(self, disambiguation):
@@ -195,8 +196,7 @@ class WikipediaSkill(MycroftSkill):
         if choice:
             self.handle_result(self.get_wiki_result(choice))
 
-    @intent_handler(IntentBuilder("").require("More").
-                    require("wiki_article").require("spoken_lines"))
+    @intent_handler(IntentBuilder("").require("More").require("wiki_article"))
     def handle_tell_more(self, message):
         """Follow up query handler, "tell me more".
 
@@ -209,12 +209,13 @@ class WikipediaSkill(MycroftSkill):
             return
 
         article = self._match
-        lines_spoken_already = int(message.data.get("spoken_lines"))
-
-        summary_read = wiki.summary(article.wiki_result, lines_spoken_already,
+        summary_read = wiki.summary(article.wiki_result,
+                                    self._lines_spoken_already,
                                     auto_suggest=article.auto_suggest)
-        summary = wiki.summary(article.wiki_result, lines_spoken_already + 5,
+        summary = wiki.summary(article.wiki_result,
+                               self._lines_spoken_already + 5,
                                auto_suggest=article.auto_suggest)
+        self._lines_spoken_already += 5
 
         # Remove already-spoken parts and section titles
         summary = summary[len(summary_read):]
@@ -227,7 +228,6 @@ class WikipediaSkill(MycroftSkill):
             self.speak(summary)
             # Update context
             self.set_context("wiki_article", "")
-            self.set_context("spoken_lines", str(lines_spoken_already+5))
 
     @intent_handler("Random.intent")
     def handle_random_intent(self, _):


### PR DESCRIPTION
Adapt builds a trie out of contexts. Sending information through them is thus not a good idea. @ken-mycroft was the one who noticed that this was a big issue.

This restores the old way of storing article match inside the skill class.

The PR also includes a fix for #60, ensuring that the original result's auto_suggest flag is honored.

#### Type of PR
If your PR fits more than one category, there is a high chance you should submit more than one PR. Please consider this carefully before opening the PR.
_Either delete those that do not apply, or add an x between the square brackets like so: `- [x]`_
- [x] Bugfix
- [ ] Feature implementation
- [ ] Refactor of code (without functional changes)
- [ ] Documentation improvements
- [ ] Test improvements


## Testing
try "tell me about goofy" and then "tell me more" and ensure the followup is ok. 