### PR TITLE
Reduce wiki calls, mainly for follow up questions

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -54,14 +54,10 @@ class PageMatch:
     This class contains the necessary data for the skills responses.
     """
     def __init__(self, result=None, auto_suggest=None):
+        self.summary = self._wiki_page_summary(result, auto_suggest)
+        self.intro_length = self._get_intro_length()
 
-        summary, lines = self._wiki_page_summary(result, auto_suggest)
-
-        self.summary = summary
-        self.lines = lines
-
-        self.image = wiki_image(wiki.page(result, auto_suggest=auto_suggest)
-        )
+        self.image = wiki_image(wiki.page(result, auto_suggest=auto_suggest))
         self.auto_suggest = auto_suggest
         self.wiki_result = result
 
@@ -77,17 +73,34 @@ class PageMatch:
             auto_suggest (bool): True if auto suggest was used to get this
                                  result.
         """
-        lines = 2
-        summary = wiki.summary(result, lines, auto_suggest=auto_suggest)
-
-        if "==" in summary or len(summary) > 250:
-            # We hit the end of the article summary or hit a really long
-            # one.  Reduce to first line.
-            lines = 1
-            summary = wiki.summary(result, lines, auto_suggest=auto_suggest)
+        summary = wiki.summary(result, auto_suggest=auto_suggest)
 
         # Clean text to make it more speakable
-        return re.sub(r'\([^)]*\)|/[^/]*/', '', summary), lines
+        return re.sub(r'\([^)]*\)|/[^/]*/', '', summary).split('.')
+
+    def _get_intro_length(self):
+        default_intro = '.'.join(self.summary[:2])
+        if len(default_intro) > 250 or '==' in default_intro:
+            return 1
+        else:
+            return 2
+
+    def get_intro(self):
+        """Get the intro sentences for the match."""
+        return self[:self.intro_length]
+
+    def __getitem__(self, val):
+        """Implements slicing for the class, returning a chunk of text.
+
+        Can either return a single sentence from the article or a range
+        of sentences. The sentences are prepared and formated into a single
+        string.
+        """
+        lines = self.summary.__getitem__(val)
+        if lines:
+            return '.'.join(lines) + '.'
+        else:
+            return ''
 
 
 def wiki_lookup(search, lang_code, auto_suggest=True):
@@ -161,8 +174,8 @@ class WikipediaSkill(MycroftSkill):
         # Remember context and speak results
         self._match = match
         self.set_context("wiki_article", "")
-        self._lines_spoken_already = match.lines
-        self.speak(match.summary)
+        self._lines_spoken_already = match.intro_length
+        self.speak(match.get_intro())
 
     def respond_disambiguation(self, disambiguation):
         """Ask for which of the different matches should be used."""
@@ -187,25 +200,18 @@ class WikipediaSkill(MycroftSkill):
             return
 
         article = self._match
-        summary_read = wiki.summary(article.wiki_result,
-                                    self._lines_spoken_already,
-                                    auto_suggest=article.auto_suggest)
-        summary = wiki.summary(article.wiki_result,
-                               self._lines_spoken_already + 5,
-                               auto_suggest=article.auto_suggest)
-        self._lines_spoken_already += 5
+        start = self._lines_spoken_already
+        stop = self._lines_spoken_already + 5
+        summary = article[start:stop]
 
-        # Remove already-spoken parts and section titles
-        summary = summary[len(summary_read):]
-        summary = re.sub(r'\([^)]*\)|/[^/]*/|== [^=]+ ==', '', summary)
-
-        if not summary:
-            self.speak_dialog("thats all")
-        else:
+        if summary:
             self.display_article(article)
             self.speak(summary)
             # Update context
+            self._lines_spoken_already += 5
             self.set_context("wiki_article", "")
+        else:
+            self.speak_dialog("thats all")
 
     @intent_handler("Random.intent")
     def handle_random_intent(self, _):

--- a/__init__.py
+++ b/__init__.py
@@ -53,17 +53,14 @@ class PageMatch:
 
     This class contains the necessary data for the skills responses.
     """
-    def __init__(self, result=None, auto_suggest=None,
-                 summary=None, lines=None, image=None):
+    def __init__(self, result=None, auto_suggest=None):
 
-        if not (summary and lines):
-            summary, lines = self._wiki_page_summary(result, auto_suggest)
+        summary, lines = self._wiki_page_summary(result, auto_suggest)
 
         self.summary = summary
         self.lines = lines
 
-        self.image = image or wiki_image(
-            wiki.page(result, auto_suggest=auto_suggest)
+        self.image = wiki_image(wiki.page(result, auto_suggest=auto_suggest)
         )
         self.auto_suggest = auto_suggest
         self.wiki_result = result
@@ -91,25 +88,6 @@ class PageMatch:
 
         # Clean text to make it more speakable
         return re.sub(r'\([^)]*\)|/[^/]*/', '', summary), lines
-
-    def serialize(self):
-        """Serialize the object to string.
-
-        Returns:
-            (str) string represenation of the object
-        """
-        return json.dumps(self.__dict__)
-
-    @classmethod
-    def deserialize(cls, data):
-        """Create a PageMatch object from serialized version."""
-        input_dict = json.loads(data)
-        return cls(result=input_dict['wiki_result'],
-                   auto_suggest=input_dict['auto_suggest'],
-                   summary=input_dict['summary'],
-                   lines=input_dict['lines'],
-                   image=input_dict['image']
-                   )
 
 
 def wiki_lookup(search, lang_code, auto_suggest=True):


### PR DESCRIPTION
#### Description
This makes the skill read the entire summary when first fetching the article and store that. In subsequent calls from `handle_tell_more()` the cached instance will be used. Adds some code to make it trivial to fetch specific lines of text from the summary.

#### Type of PR
If your PR fits more than one category, there is a high chance you should submit more than one PR. Please consider this carefully before opening the PR.
_Either delete those that do not apply, or add an x between the square brackets like so: `- [x]`_
- [ ] Bugfix
- [x] Feature implementation
- [ ] Refactor of code (without functional changes)
- [ ] Documentation improvements
- [ ] Test improvements

#### Testing
Check that VK tests still passes and that the wiki articles sounds ok.