### PR TITLE
WIP: Other ideas for Common Query in Wiki Skill

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -92,25 +92,6 @@ class PageMatch:
         # Clean text to make it more speakable
         return re.sub(r'\([^)]*\)|/[^/]*/', '', summary), lines
 
-    def serialize(self):
-        """Serialize the object to string.
-
-        Returns:
-            (str) string represenation of the object
-        """
-        return json.dumps(self.__dict__)
-
-    @classmethod
-    def deserialize(cls, data):
-        """Create a PageMatch object from serialized version."""
-        input_dict = json.loads(data)
-        return cls(result=input_dict['wiki_result'],
-                   auto_suggest=input_dict['auto_suggest'],
-                   summary=input_dict['summary'],
-                   lines=input_dict['lines'],
-                   image=input_dict['image']
-                   )
-
 
 def wiki_lookup(search, lang_code, auto_suggest=True):
     """Performs a wikipedia article lookup.

--- a/__init__.py
+++ b/__init__.py
@@ -178,7 +178,10 @@ class WikipediaSkill(CommonQuerySkill):
         result = self.get_wiki_result(query)
         if result is not None:
             if isinstance(result, PageMatch):
+                self._match = result
+                self.set_context("wiki_article", "")
                 result = result.summary
+
             elif isinstance(result, PageDisambiguation):
                 # currently uinsupported under common query
                 #self.respond_disambiguation(result)

--- a/regex/en-us/article.title.rx
+++ b/regex/en-us/article.title.rx
@@ -1,1 +1,2 @@
 .*(wiki|for|about|wikipedia)(?! (for|about)) (?P<ArticleTitle>.+)
+.* (wiki|for|about|wikipedia)(?! (for|about)) (?P<ArticleTitle>.+)

--- a/vocab/en-us/Wikipedia.voc
+++ b/vocab/en-us/Wikipedia.voc
@@ -1,6 +1,4 @@
 wiki
 wikipedia
-tell me about
-tell us about
 what does wikipedia say about
 search


### PR DESCRIPTION
An alternative example of PR #62 that retains the existing functionality:
- direct query intents if a user specifically requests wikipedia
- follow up queries for more information

Note: I haven't updated any tests to account for the Skill not responding directly to "tell me about..." 

Questions:
- Should Common Query Skills have their own intents independent of the Query Fallback Skill? 
- Should we be doing follow up from these Skills? I'm thinking it makes sense given they had the highest confidence in handling the initial response and hence a better chance at providing the most consistent additional information.

