### PR TITLE
add specific intent handling for ask wiki, etc and convert to a commo…

### DIFF
--- a/dialog/en-us/wiki.specific.response.dialog
+++ b/dialog/en-us/wiki.specific.response.dialog
@@ -1,0 +1,1 @@
+Here is your answer from wiki peedia

--- a/test/README.md
+++ b/test/README.md
@@ -1,0 +1,24 @@
+Note, the wiki skill and the duck duck go skill are now common query skills
+and as such behave differently than previous versions of the skill. As a 
+result the VK tests were restructured a bit. 
+
+Now specific query skills can be called out by name. So for example, the 
+utterance "ask wiki bla" will be handled by the wiki skill intent handler.
+The response now begins with the dialog "here is your answer from wikipedia" 
+so this must be handled first before we can interrogate the contents of the
+response.
+
+This is not the case when common query handles the request and wiki wins
+the confidence battle. In that case a different response is sent by the 
+system to the user and those messages must be processed differently.
+
+Also new to this testing process is the use of the new audio/speak stop
+message recently introduced into the tts module. This reduces overall 
+test execution time as without this we would be waiting for up to 2 minutes
+for a wiki response to be spoken. Now we just stop the tts output once we
+get our next speak message.
+
+The person testing was also expanded to meet the Wikipedia.vocab file.
+
+Finally, note these test only test the intent portion of this skill. To
+test the skill from the common query perspective see those VK tests.

--- a/test/behave/steps/wiki.py
+++ b/test/behave/steps/wiki.py
@@ -1,11 +1,24 @@
 import time 
 
-from behave import then
-
+from behave import then, when
+from mycroft.messagebus import Message
 from mycroft.audio import wait_while_speaking
+from test.integrationtests.voight_kampff import then_wait
 
-@then('wait while speaking')
-def handle_wait(context):
-    # add sleep to ensure there is a delay when using a dummy TTS eg CI
-    time.sleep(3)
-    wait_while_speaking()
+@when('dialog is stopped')
+def when_dialog_is_stopped(context):
+    context.bus.emit(Message('mycroft.audio.speech.stop',
+                             data={},
+                             context={}))
+
+@then('"{skill}" should reply with dialog "{dialog}"')
+def then_dialog(context, skill, dialog):
+    def check_dialog(message):
+        utt_dialog = message.data.get('utterance', '')
+        return (utt_dialog == 'Here is your answer from wiki peedia', '')
+
+    passed, debug = then_wait('speak', check_dialog, context)
+    if not passed:
+        assert_msg = debug
+
+    assert passed, assert_msg or 'Mycroft didn\'t respond'

--- a/test/behave/wiki.feature
+++ b/test/behave/wiki.feature
@@ -3,36 +3,42 @@ Feature: Wikipedia Skill
   Scenario Outline: user asks a question about a person
     Given an english speaking user
      When the user says "<tell me about a person>"
-     Then "skill-wiki" should reply with dialog from "searching.dialog"
-     And wait while speaking
-     And mycroft reply should contain "<person>"
+     Then "skill-wiki" should reply with dialog "wiki.specific.response.dialog"
+     When dialog is stopped
+     Then mycroft reply should contain "<person>"
 
   Examples: user asks a question about a person
     | tell me about a person | person |
-    | tell me about abraham lincoln | lincoln |
-    | tell me about nelson mandela | mandela |
-    | tell me about queen elizabeth | elizabeth |
-    | tell me about Mahatma Gandhi | gandhi |
     | tell me about the president of the united states | president |
-    | tell me about the secretary general of the united nations | secretary |
+    | ask wiki who was abraham lincoln | lincoln |
+    | ask wiki who were the beatles | beatles |
+    | tell me who was alexander the great | alexander |
+    | tell us about nelson mandela | mandela |
+    | ask wikipedia who is queen elizabeth | elizabeth |
+    | what does wikipedia say about Mahatma Gandhi | gandhi |
+    | what does wiki say about al capone | capone |
+    | ask wiki what is the secretary general of the united nations | secretary |
+    | tell me who is the secretary general of the united nations | secretary |
 
-  @xfail
-  Scenario Outline: Failing user asks a question about a person
+
+  Scenario Outline: user asks a question about a person
     Given an english speaking user
      When the user says "<tell me about a person>"
-     Then "skill-wiki" should reply with dialog from "searching.dialog"
-     And mycroft reply should contain "<person>"
+     Then "skill-wiki" should reply with dialog "wiki.specific.response.dialog"
+     When dialog is stopped
+     Then mycroft reply should contain "<person>"
 
   Examples: user asks a question about a person
     | tell me about a person | person |
     | tell me about George Church | church |
 
+
   Scenario Outline: user asks a question about a place
     Given an english speaking user
      When the user says "<tell me about a place>"
-     Then "mycroft-wiki" should reply with dialog from "searching.dialog"
-     And wait while speaking
-     And mycroft reply should contain "<place>"
+     Then "skill-wiki" should reply with dialog "wiki.specific.response.dialog"
+     When dialog is stopped
+     Then mycroft reply should contain "<place>"
 
   Examples: user asks a question about a place
     | tell me about a place | place |
@@ -40,39 +46,33 @@ Feature: Wikipedia Skill
     | tell me about tokyo | japan |
     | tell me about antarctica | pole |
 
-  Scenario Outline: user asks a question about something
+
+  Scenario Outline: user asks a question about a something
     Given an english speaking user
      When the user says "<tell me about a thing>"
-     Then "mycroft-wiki" should reply with dialog from "searching.dialog"
-     And wait while speaking
-     And mycroft reply should contain "<thing>"
+     Then "skill-wiki" should reply with dialog "wiki.specific.response.dialog"
+     When dialog is stopped
+     Then mycroft reply should contain "<thing>"
 
   Examples: user asks a question about a thing
     | tell me about a thing | thing |
     | tell me about sandwiches | sandwich |
     | tell me about hammers | hammer |
+    | ask wikipedia what is an automobile | car |
+    | ask wiki what is a car | car |
+    | what can wiki tell us about failures | failure |
 
-  @xfail
-  # Jira MS-79 https://mycroft.atlassian.net/browse/MS-79
-  Scenario Outline: failing queries
-    Given an english speaking user
-     When the user says "<tell me about failures>"
-     Then "mycroft-wiki" should reply with dialog from "searching.dialog"
-     And mycroft reply should contain "<failure>"
-
-  Examples: failing things
-    | tell me about failures | failure |
-    | tell me about automobiles | automobile |
 
   Scenario Outline: user asks a question about an idea
     Given an english speaking user
      When the user says "<tell me about an idea>"
-     Then "mycroft-wiki" should reply with dialog from "searching.dialog"
-     And wait while speaking
-     And mycroft reply should contain "<idea>"
+     Then "skill-wiki" should reply with dialog "wiki.specific.response.dialog"
+     When dialog is stopped
+     Then mycroft reply should contain "<idea>"
 
   Examples: user asks a question about an idea
     | tell me about an idea | idea |
     | tell me about philosophy | philosophy |
-    | tell me about politics | politics |
-    | tell me about science | knowledge |
+    | ask wiki what is politics | politics |
+    | tell us about science | knowledge |
+

--- a/vocab/en-us/Wikipedia.voc
+++ b/vocab/en-us/Wikipedia.voc
@@ -1,6 +1,13 @@
-wiki
+what does wikipedia say about
+what does wiki say about
+ask wikipedia
+ask wiki
 wikipedia
+wiki
+tell me about the
+tell us about the
 tell me about
 tell us about
-what does wikipedia say about
+tell me
+tell us
 search


### PR DESCRIPTION
…n query skill

#### Description
Adds specific intent for calling out the skill by name. For example, ask wiki or wiki, tell us about bla.

Also converts the skill to a common query skill. 

I removed manual disambiguation and replaced it with auto disambiguation and I fixed the bug where when you ask wiki what is an automobile it responds with what is a cat. This was due to the auto suggest feature which has been entirely removed. If in the future if bugs like this can be corrected we could add it back as it was a good idea but just not working. 

I removed the 'more' feature as these skills now return more by default but because of corrected barge-in you can now simply say 'stop', which the VK tests do to improve performance.

I refactored the code (specifically the new fix_input() routine) but it still leaves a lot to be desired. The president of the united states returns none but now it returns the original query when this happens which also improves its ability to answer a wider range of questions.

I also corrected and added VK tests and a readme file in the test directory describing these enhancements and added code to the steps file.

#### Type of PR

- [ x ] Bugfix
- [ x ] Feature implementation
- [ x ] Refactor of code (without functional changes)
- [ x ] Documentation improvements
- [ x ] Test improvements

#### Testing
How can someone reviewing this PR test that it is working properly? Is there appropriate test coverage for this change?

VK tests

#### Documentation
Readme file added to test directory

