### PR TITLE
Feature/better images

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -28,18 +28,25 @@ EXCLUDED_IMAGES = [
 
 class WikipediaSkill(CommonQuerySkill):
     def __init__(self):
-        """ self.auto_more (bool): From config "cq_auto_more": if true will
-           return abbreviated (2 lines) and handle 
-           'more'. If false (or not present), will
-           return entire abstract and handle 'stop'"""
+        """Constructor for WikipediaSkill.
+
+        Attributes:
+            _match (PageMatch): current match in case user requests more info
+            _lines_spoken_already (int): number of lines already spoken from _match.summary
+            translated_question_words (list[str]): used in cleaning queries
+            translated_question_verbs (list[str]): used in cleaning queries
+            translated_articles (list[str]): used in cleaning queries
+            auto_more (bool): default false
+                Set by cq_auto_more attribute in mycroft.conf
+                If true will read 20 lines of abstract for any query.
+                If false will read first 2 lines and wait for request to read more.
+        """
         super(WikipediaSkill, self).__init__(name="WikipediaSkill")
         self._match = None
         self._lines_spoken_already = 0
-
         self.translated_question_words = self.translate_list("question_words")
         self.translated_question_verbs = self.translate_list("question_verbs")
         self.translated_articles = self.translate_list("articles")
-
         self.auto_more = self.config_core.get('cq_auto_more', False)
 
     @intent_handler(AdaptIntent("").require("Wikipedia").

--- a/__init__.py
+++ b/__init__.py
@@ -21,10 +21,6 @@ from mycroft.util.format import join_list
 from .wiki.pages import PageMatch, PageDisambiguation, PageError
 from .wiki.search import get_random_wiki_page, wiki_lookup
 
-EXCLUDED_IMAGES = [
-    'https://upload.wikimedia.org/wikipedia/commons/7/73/Blue_pencil.svg'
-]
-
 
 class WikipediaSkill(CommonQuerySkill):
     def __init__(self):

--- a/__init__.py
+++ b/__init__.py
@@ -16,7 +16,6 @@ from concurrent.futures import ThreadPoolExecutor
 
 from mycroft.skills import AdaptIntent, intent_handler
 from mycroft.skills.common_query_skill import CommonQuerySkill, CQSMatchLevel
-from mycroft.skills.skill_data import read_vocab_file
 from mycroft.util.format import join_list
 
 from .wiki.pages import PageMatch, PageDisambiguation, PageError
@@ -36,13 +35,6 @@ class WikipediaSkill(CommonQuerySkill):
         super(WikipediaSkill, self).__init__(name="WikipediaSkill")
         self._match = None
         self._lines_spoken_already = 0
-
-        fname = self.find_resource("Wikipedia.voc", res_dirname="vocab")
-        temp = read_vocab_file(fname)
-        vocab = []
-        for item in temp:
-            vocab.append(" ".join(item))
-        self.sorted_vocab = sorted(vocab, key=lambda x: (-len(x), x))
 
         self.translated_question_words = self.translate_list("question_words")
         self.translated_question_verbs = self.translate_list("question_verbs")

--- a/__init__.py
+++ b/__init__.py
@@ -16,6 +16,7 @@ import re
 from concurrent.futures import ThreadPoolExecutor
 
 import wikipedia as wiki
+from mycroft.audio import wait_while_speaking
 from mycroft.skills import AdaptIntent, intent_handler
 from mycroft.skills.common_query_skill import CommonQuerySkill, CQSMatchLevel
 from mycroft.skills.skill_data import read_vocab_file
@@ -310,9 +311,11 @@ class WikipediaSkill(CommonQuerySkill):
             match (PageMatch): wiki page match
         """
         self.gui.clear()
+        self.gui['title'] = match.wiki_result
         self.gui['summary'] = match.summary
         self.gui['imgLink'] = match.image
-        self.gui.show_page("WikipediaDelegate.qml", override_idle=60)
+        self.gui.show_image(match.image, title=match.wiki_result)
+        # self.gui.show_page("WikipediaDelegate.qml", override_idle=60)
 
     def respond(self, query):
         """determine if we have a page match or 

--- a/__init__.py
+++ b/__init__.py
@@ -49,7 +49,7 @@ class WikipediaSkill(CommonQuerySkill):
         self.translated_articles = self.translate_list("articles")
         self.auto_more = self.config_core.get('cq_auto_more', False)
 
-    @intent_handler(AdaptIntent("").require("Wikipedia").
+    @intent_handler(AdaptIntent().require("Wikipedia").
                     require("ArticleTitle"))
     def handle_wiki_query(self, message):
         """Extract what the user asked about and reply with info from wikipedia.
@@ -99,7 +99,7 @@ class WikipediaSkill(CommonQuerySkill):
         if choice:
             self.handle_result(self.get_wiki_result(choice))
 
-    @intent_handler(AdaptIntent("").require("More").require("wiki_article"))
+    @intent_handler(AdaptIntent().require("More").require("wiki_article"))
     def handle_tell_more(self, message):
         """Follow up query handler, "tell me more".
 

--- a/__init__.py
+++ b/__init__.py
@@ -21,6 +21,7 @@ from mycroft.skills.common_query_skill import CommonQuerySkill, CQSMatchLevel
 from mycroft.skills.skill_data import read_vocab_file
 from mycroft.util.format import join_list
 from mycroft.util.log import LOG
+from quebra_frases import sentence_tokenize
 
 EXCLUDED_IMAGES = [
     'https://upload.wikimedia.org/wikipedia/commons/7/73/Blue_pencil.svg'
@@ -85,7 +86,9 @@ class PageMatch:
         summary = wiki.summary(result, auto_suggest=auto_suggest)
 
         # Clean text to make it more speakable
-        return re.sub(r'\([^)]*\)|/[^/]*/', '', summary).split('.')
+        summary = re.sub(r'\([^)]*\)|/[^/]*/', '', summary)
+        summary = re.sub(r'\s+', ' ', summary)
+        return sentence_tokenize(summary)
 
     def _get_intro_length(self):
         default_intro = '.'.join(self.summary[:2])
@@ -107,7 +110,7 @@ class PageMatch:
         """
         lines = self.summary.__getitem__(val)
         if lines:
-            return '.'.join(lines) + '.'
+            return ''.join(lines)
         else:
             return ''
 

--- a/__init__.py
+++ b/__init__.py
@@ -90,7 +90,7 @@ class PageMatch:
         return sentence_tokenize(summary)
 
     def _get_intro_length(self):
-        default_intro = '.'.join(self.summary[:2])
+        default_intro = '. '.join(self.summary[:2])
         if len(default_intro) > 250 or '==' in default_intro:
             return 1
         else:
@@ -109,7 +109,7 @@ class PageMatch:
         """
         lines = self.summary.__getitem__(val)
         if lines:
-            return ''.join(lines)
+            return ' '.join(lines)
         else:
             return ''
 
@@ -339,7 +339,7 @@ class WikipediaSkill(CommonQuerySkill):
                 result = result[:20]
             else:
                 result = result[:2]
-        return ''.join(result)
+        return ' '.join(result)
 
     def fix_input(self, query):
         for noun in self.translated_question_words:

--- a/__init__.py
+++ b/__init__.py
@@ -64,7 +64,7 @@ class PageMatch:
 
         self.summary = self._wiki_page_summary(result, auto_suggest)
         self.intro_length = self._get_intro_length()
-        self.image = wiki_image(wiki.page(result, auto_suggest=auto_suggest))
+        self.wiki_page = wiki.page(result, auto_suggest=auto_suggest)
 
     def _wiki_page_summary(self, result: str, auto_suggest: bool) -> list([str]):
         """Request the summary for the result.
@@ -111,6 +111,11 @@ class PageMatch:
             return ''.join(lines)
         else:
             return ''
+
+    def get_image(self):
+        """Fetch image for this wiki page."""
+        self.image = wiki_image(self.wiki_page)
+        return self.image
 
 
 def wiki_lookup(search, lang_code, auto_suggest=True):
@@ -196,6 +201,7 @@ class WikipediaSkill(CommonQuerySkill):
 
     def respond_match(self, match):
         """Read short summary to user."""
+        match.get_image()
         self.display_article(match)
         # Remember context and speak results
         self._match = match

--- a/__init__.py
+++ b/__init__.py
@@ -16,7 +16,6 @@ import re
 from concurrent.futures import ThreadPoolExecutor
 
 import wikipedia as wiki
-from mycroft.audio import wait_while_speaking
 from mycroft.skills import AdaptIntent, intent_handler
 from mycroft.skills.common_query_skill import CommonQuerySkill, CQSMatchLevel
 from mycroft.skills.skill_data import read_vocab_file
@@ -113,10 +112,10 @@ class PageMatch:
                 image = images[0]
         return image
 
-    def get_image(self):
-        """Fetch image for this wiki page."""
-        self.image = self._find_best_image()
-        return self.image
+    @property
+    def image(self):
+        """Image for this wiki page."""
+        return self._find_best_image()
 
 
 def wiki_lookup(search, lang_code, auto_suggest=True):
@@ -202,7 +201,6 @@ class WikipediaSkill(CommonQuerySkill):
 
     def respond_match(self, match):
         """Read short summary to user."""
-        match.get_image()
         self.display_article(match)
         # Remember context and speak results
         self._match = match
@@ -402,7 +400,6 @@ class WikipediaSkill(CommonQuerySkill):
             answer, result = self._get_answer_for_query(cleaned_query)
 
         if result:
-            result.get_image()
             callback_data = {
                 'title': result.wiki_result,
                 'summary': result.summary,

--- a/__init__.py
+++ b/__init__.py
@@ -16,8 +16,7 @@ import re
 from concurrent.futures import ThreadPoolExecutor
 
 import wikipedia as wiki
-from mycroft import intent_handler
-from mycroft.skills import AdaptIntent
+from mycroft.skills import AdaptIntent, intent_handler
 from mycroft.skills.common_query_skill import CommonQuerySkill, CQSMatchLevel
 from mycroft.skills.skill_data import read_vocab_file
 from mycroft.util.format import join_list
@@ -58,18 +57,16 @@ class PageMatch:
     """
 
     def __init__(self, result=None, auto_suggest=None,
-                 summary=None, lines=None, image=None,
                  auto_more=False):
 
         self.auto_more = auto_more
 
-        if not (summary and lines):
-            summary, lines = self._wiki_page_summary(result, auto_suggest)
+        summary, lines = self._wiki_page_summary(result, auto_suggest)
 
         self.summary = summary
         self.lines = lines
 
-        self.image = image or wiki_image(
+        self.image = wiki_image(
             wiki.page(result, auto_suggest=auto_suggest)
         )
         self.auto_suggest = auto_suggest

--- a/__init__.py
+++ b/__init__.py
@@ -47,26 +47,25 @@ class PageMatch:
         self.wiki_result = result
         self.auto_suggest = auto_suggest
 
-        self.summary = self._wiki_page_summary(result, auto_suggest)
-        self.intro_length = self._get_intro_length()
         self.page = wiki.page(result, auto_suggest=auto_suggest)
+        self.summary = self._get_page_summary()
+        self.intro_length = self._get_intro_length()
 
-    def _wiki_page_summary(self, result: str, auto_suggest: bool) -> list([str]):
-        """Request the summary for the result.
+    def _get_page_summary(self) -> list([str]):
+        """Get the summary from the wiki page.
 
-        writes in inverted-pyramid style, so the first sentence is the
-        most important, the second less important, etc.  Two sentences
+        Writes in inverted-pyramid style, so the first sentence is the
+        most important, the second less important, etc. Two sentences
         is all we ever need.
-
-        Arguments:
-            wiki result (str): Wikipedia match name
-            auto_suggest (bool): True if auto suggest was used to get this
-                                 result.
 
         Returns
             List: summary as list of sentences
         """
-        summary = wiki.summary(result, auto_suggest=auto_suggest)
+        if hasattr(self.page, 'summary'):
+            summary = self.page.summary
+        else:
+            summary = wiki.summary(
+                self.wiki_result, auto_suggest=self.auto_suggest)
 
         # Clean text to make it more speakable
         summary = re.sub(r'\([^)]*\)|/[^/]*/', '', summary)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 wikipedia==1.4.0
+quebra-frases~=0.3.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,7 @@
-wikipedia==1.4.0
-quebra-frases~=0.3.4
+# This fork of the Wikipedia package contains a fix fetching the correct 
+# thumbnail image. The Wikipedia package is abandonware and has a large
+# number of outstanding PR's. There are a few forks and new projects around.
+# However at present this still serves our purposes. It's highly likely that
+# an alternative will need to be selected for functionality improvements.
+https://github.com/davidedmundson/Wikipedia/tarball/0b6c67d152e1a4a2c28d9793dda674213b0071d8
+quebra-frases~=0.3.7

--- a/test/behave/steps/wiki.py
+++ b/test/behave/steps/wiki.py
@@ -11,17 +11,11 @@ def dialog_is_stopped(context):
         who = message.data.get('by', '')
         return (who == 'TTS', '')
 
-    def check_dialog_mycroft_stop(message):
-        return True, ''
-
     context.bus.emit(Message('mycroft.audio.speech.stop',
                              data={},
                              context={}))
     status, debug = then_wait("mycroft.stop.handled", check_dialog_tts_stop, context, 5)
-    if status:
-        return status, debug
-
-    return then_wait("mycroft.stop", check_dialog_mycroft_stop, context, 5)
+    return status, debug
 
 
 @then('"{skill}" should reply with dialog "{dialog}"')

--- a/wiki/__init__.py
+++ b/wiki/__init__.py
@@ -1,0 +1,16 @@
+# Copyright 2021, Mycroft AI Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .pages import PageDisambiguation, PageError, PageMatch
+from .search import get_random_wiki_page, wiki_lookup

--- a/wiki/pages.py
+++ b/wiki/pages.py
@@ -1,0 +1,110 @@
+# Copyright 2021, Mycroft AI Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import re
+
+from quebra_frases import sentence_tokenize
+
+import wikipedia
+from wikipedia import PageError
+
+
+class PageDisambiguation:
+    """Class representing a disambiguation request."""
+
+    def __init__(self, options):
+        self.options = options[:5]
+
+
+class PageMatch:
+    """Representation of a wiki page match.
+
+    This class contains the necessary data for the skills responses.
+    """
+
+    def __init__(self, result=None, auto_suggest=None):
+
+        self.wiki_result = result
+        self.auto_suggest = auto_suggest
+
+        self.page = wikipedia.page(result, auto_suggest=auto_suggest)
+        self.summary = self._get_page_summary()
+        self.intro_length = self._get_intro_length()
+
+    def _get_page_summary(self) -> list([str]):
+        """Get the summary from the wiki page.
+
+        Writes in inverted-pyramid style, so the first sentence is the
+        most important, the second less important, etc. Two sentences
+        is all we ever need.
+
+        Returns
+            List: summary as list of sentences
+        """
+        if hasattr(self.page, 'summary'):
+            summary = self.page.summary
+        else:
+            summary = wikipedia.summary(
+                self.wiki_result, auto_suggest=self.auto_suggest)
+
+        # Clean text to make it more speakable
+        summary = re.sub(r'\([^)]*\)|/[^/]*/', '', summary)
+        summary = re.sub(r'\s+', ' ', summary)
+        return sentence_tokenize(summary)
+
+    def _get_intro_length(self):
+        default_intro = '. '.join(self.summary[:2])
+        if len(default_intro) > 250 or '==' in default_intro:
+            return 1
+        else:
+            return 2
+
+    def get_intro(self):
+        """Get the intro sentences for the match."""
+        return self[:self.intro_length]
+
+    def __getitem__(self, val):
+        """Implements slicing for the class, returning a chunk of text.
+
+        Can either return a single sentence from the article or a range
+        of sentences. The sentences are prepared and formated into a single
+        string.
+        """
+        lines = self.summary.__getitem__(val)
+        if lines:
+            return ' '.join(lines)
+        else:
+            return ''
+
+    def _find_best_image(self):
+        """Find the best image for this wiki page.
+
+        Preference given to the official thumbnail.
+
+        Returns:
+            (str) image url or empty string if no image available
+        """
+        image = ''
+        if hasattr(self.page, 'thumbnail'):
+            image = self.page.thumbnail
+        else:
+            images = [i for i in self.page.images if i not in EXCLUDED_IMAGES]
+            if len(images) > 0:
+                image = images[0]
+        return image
+
+    @property
+    def image(self):
+        """Image for this wiki page."""
+        return self._find_best_image()

--- a/wiki/pages.py
+++ b/wiki/pages.py
@@ -19,6 +19,10 @@ from quebra_frases import sentence_tokenize
 import wikipedia
 from wikipedia import PageError
 
+EXCLUDED_IMAGES = [
+    'https://upload.wikimedia.org/wikipedia/commons/7/73/Blue_pencil.svg'
+]
+
 
 class PageDisambiguation:
     """Class representing a disambiguation request."""

--- a/wiki/search.py
+++ b/wiki/search.py
@@ -1,0 +1,51 @@
+# Copyright 2021, Mycroft AI Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import wikipedia
+
+from .pages import PageDisambiguation, PageMatch
+
+
+def get_random_wiki_page():
+    """Get a random wikipedia page."""
+    return wikipedia.random(pages=1)
+
+def wiki_lookup(search, lang_code, auto_suggest=True):
+    """Performs a wikipedia article lookup.
+
+    Arguments:
+        search (str): phrase to search for
+        lang_code (str): wikipedia language code to use
+        auto_suggest (bool): wether or not to use autosuggest.
+
+    Returns:
+        PageMatch, PageDisambiguation or None
+    """
+    try:
+        # Use the version of Wikipedia appropriate to the request language
+        wikipedia.set_lang(lang_code)
+
+        # Fetch wiki article titles. This comes back
+        # as a list.  I.e. "beans" returns ['beans',
+        #     'Beans, Beans the Music Fruit', 'Phaseolus vulgaris',
+        #     'Baked beans', 'Navy beans']
+        results = wikipedia.search(search, 5)
+        if len(results) == 0:
+            return None
+
+        return PageMatch(results[0], auto_suggest)
+
+    except wikipedia.exceptions.DisambiguationError as e:
+        # Test: "tell me about john"
+        return PageDisambiguation(e.options)


### PR DESCRIPTION
#### Description
* Get better images - now uses page thumbnail by default. This gives you a picture of Nikolas Tesla rather than a picture of an airport terminal named after him.
* Display image if selected by Common Query to answer.
* Switch back to short summary by default. `if auto_more == True` the Skill will automatically read more.
* Refactor Wikipedia interface into submodule
* Restore parallel auto_suggest vs no_auto_suggest lookups, but preference the result without auto_suggest.
* Reduce number of calls to Wikipedia. Most data is available on the PageMatch object, so first try there. Only if that doesn't exist should we make another call.
* General clean up and refactoring.

#### Todo
* Combine two display methods
* Consider addition of match cache using page title as key - this also means data doesn't need to be passed to CQS and back, only the key.
* Add new GUI.

#### Type of PR
- [x] Bugfix
- [x] Feature implementation
- [x] Refactor of code (without functional changes)

#### Testing
```
mycroft-start vktest -t mycroft-wiki
```

#### CLA
- [x] Yes