### PR TITLE
Report VisualMatchLevel to Common Query

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -18,7 +18,7 @@ from urllib3.exceptions import HTTPError
 from requests.exceptions import ConnectionError, ReadTimeout
 
 from mycroft import AdaptIntent, intent_handler
-from mycroft.skills.common_query_skill import CommonQuerySkill, CQSMatchLevel
+from mycroft.skills.common_query_skill import CommonQuerySkill, CQSVisualMatchLevel
 
 from .wiki import Wiki, DisambiguationError, MediaWikiPage
 
@@ -158,7 +158,7 @@ class WikipediaSkill(CommonQuerySkill):
         else:
             self.speak_dialog("thats all")
 
-    def CQS_match_query_phrase(self, query: str) -> tuple([str, CQSMatchLevel, str, dict]):
+    def CQS_match_query_phrase(self, query: str) -> tuple([str, CQSVisualMatchLevel, str, dict]):
         """Respond to Common Query framework with best possible answer.
 
         Args:
@@ -188,7 +188,7 @@ class WikipediaSkill(CommonQuerySkill):
             self._cqs_match = Article(page.title, page, answer, num_lines)
         if answer:
             self.schedule_event(self.get_cqs_match_image, 0)
-            return (query, CQSMatchLevel.CATEGORY, answer, callback_data)
+            return (query, CQSVisualMatchLevel.CATEGORY, answer, callback_data)
         return answer
 
     def CQS_action(self, phrase: str, data: dict):


### PR DESCRIPTION
#### Description
CQSVisualMatchLevel provides a small bonus to the match confidence if the platform has a GUI connected.

All the default CQS Skills should have GUI's, but this will be important as more Skills register to this system.

#### Type of PR
- [ ] Bugfix
- [x] Feature implementation
- [ ] Refactor of code (without functional changes)
- [ ] Documentation improvements
- [ ] Test improvements

#### Testing
Make a query via CQS and ensure Wikipedia still responds. You can also log the confidence levels to see it change.

#### Documentation
Detail on the `CQSVisualMatchLevel` has been added to the Common Query page of the docs.

#### CLA
- [x] Yes